### PR TITLE
Tweak expect_path error message to be clearer

### DIFF
--- a/cli_test_dir/src/lib.rs
+++ b/cli_test_dir/src/lib.rs
@@ -236,7 +236,7 @@ impl TestDir {
     /// If `path` does not point to valid path, fail the current test.
     pub fn expect_path<P: AsRef<Path>>(&self, path: P) {
         let path = self.dir.join(path);
-        assert!(path.exists(), format!("{} exists", path.display()));
+        assert!(path.exists(), format!("{} should exist", path.display()));
     }
 
     /// Verify that the file contains the specified data.


### PR DESCRIPTION
I thought the panic at "foo.txt exists" meant the file _shouldn't_ exist but _did_; turns out the error means the exact opposite: it couldn't find the expected file. "foo.txt should exist" reads as a clearer error message to me.